### PR TITLE
Add 'get' and 'list' to required RBAC API group cluster roles

### DIFF
--- a/deploy/cluster_roles.yaml
+++ b/deploy/cluster_roles.yaml
@@ -98,7 +98,7 @@ rules:
 
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["clusterroles"]
-    verbs: ["create","patch","watch","delete"]
+    verbs: ["get","create","list","patch","watch","delete"]
 
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["clusterrolebindings"]


### PR DESCRIPTION
Parent issue: https://github.com/eclipse/codewind/issues/2562