### PR TITLE
Add CRDs for Openshift 3.11 clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,24 @@ $ kubectl create -f ./deploy/cluster_roles.yaml
 (permissions at namespace level not sufficient, need permissions at cluster level, talk to services outside of namespace)
 $ kubectl create -f ./deploy/cluster_role_binding.yaml 
 (connects service account to role)
+```
+
+Create the CRD.  For Openshift 3.11.x clusters: 
+
+```
+$ kubectl create -f ./deploy/crds/codewind.eclipse.org_keycloaks_crd-oc311.yaml 
+$ kubectl create -f ./deploy/crds/codewind.eclipse.org_codewinds_crd-oc311.yaml
+```
+
+For other versions of Openshift and Kubernetes: 
+
+```
 $ kubectl create -f ./deploy/crds/codewind.eclipse.org_keycloaks_crd.yaml 
-(extend kube api to make aware of keycloak)
 $ kubectl create -f ./deploy/crds/codewind.eclipse.org_codewinds_crd.yaml 
-(extend kube api to make aware of codewind)
+```
+
+Deploy the operator
+```
 $ kubectl create -f ./deploy/operator.yaml 
 (downloads images into the cluster)
 ```

--- a/deploy/crds/codewind.eclipse.org_codewinds_crd-oc311.yaml
+++ b/deploy/crds/codewind.eclipse.org_codewinds_crd-oc311.yaml
@@ -1,0 +1,104 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: codewinds.codewind.eclipse.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.username
+    description: Deployment reference name
+    name: Username
+    type: string
+  - JSONPath: .metadata.namespace
+    description: Deployment namespace
+    name: Namespace
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of the resource
+    name: Age
+    type: date
+  - JSONPath: .spec.keycloakDeployment
+    description: Deployment reference name
+    name: Keycloak
+    type: string
+  - JSONPath: .status.keycloakStatus
+    description: Keycloak configuration status
+    name: Registration
+    type: string
+  - JSONPath: .status.accessURL
+    description: Exposed route
+    name: AccessURL
+    type: string
+  group: codewind.eclipse.org
+  names:
+    kind: Codewind
+    listKind: CodewindList
+    plural: codewinds
+    singular: codewind
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Codewind is the Schema for the codewinds API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          ###type: object
+        spec:
+          description: CodewindSpec defines the desired state of Codewind
+          properties:
+            keycloakDeployment:
+              description: 'KeycloakDeployment : name of the keycloak deployment used
+                by this instance of codewind'
+              pattern: ^[A-Za-z0-9/-]*$
+              type: string
+            logLevel:
+              description: LogLevel within pods
+              type: string
+            storageSize:
+              description: Codewind Storage size
+              pattern: '[0-9]*Gi$'
+              type: string
+            username:
+              description: Developer username assigned to this instance
+              pattern: ^[A-Za-z0-9/-]*$
+              type: string
+          required:
+          - keycloakDeployment
+          - logLevel
+          - storageSize
+          - username
+          ###type: object
+        status:
+          description: CodewindStatus defines the observed state of Codewind
+          properties:
+            accessURL:
+              description: Exposed Ingress of Codewind (Gatekeeper)
+              type: string
+            authURL:
+              description: 'Important: Run "operator-sdk generate k8s" to regenerate
+                code after modifying this file Keycloak access URL'
+              type: string
+            keycloakStatus:
+              description: Keycloak Configuration status
+              type: string
+          required:
+          - accessURL
+          - authURL
+          - keycloakStatus
+          ###type: object
+      ###type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/crds/codewind.eclipse.org_keycloaks_crd-oc311.yaml
+++ b/deploy/crds/codewind.eclipse.org_keycloaks_crd-oc311.yaml
@@ -1,0 +1,77 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: keycloaks.codewind.eclipse.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.namespace
+    description: Deployment namespace
+    name: Namespace
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of the resource
+    name: Age
+    type: date
+  - JSONPath: .status.url
+    description: Exposed route
+    name: Access
+    type: string
+  group: codewind.eclipse.org
+  names:
+    kind: Keycloak
+    listKind: KeycloakList
+    plural: keycloaks
+    singular: keycloak
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Keycloak is the Schema for the keycloaks API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          ###type: object
+        spec:
+          description: KeycloakSpec defines the desired state of Keycloak
+          properties:
+            storageSize:
+              description: 'Important: Run "operator-sdk generate k8s" to regenerate
+                code after modifying this file StorageSize : Size of the Keycloak
+                PVC'
+              pattern: '[0-9]*Gi$'
+              type: string
+          required:
+          - storageSize
+          ###type: object
+        status:
+          description: KeycloakStatus defines the observed state of Keycloak
+          properties:
+            defaultRealm:
+              type: string
+            phase:
+              description: 'Important: Run "operator-sdk generate k8s" to regenerate
+                code after modifying this file'
+              type: string
+            url:
+              type: string
+          required:
+          - defaultRealm
+          - phase
+          - url
+          ###type: object
+      ###type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true


### PR DESCRIPTION
## Problem

The older Openshift 3.11 API rejects format of Codewind and Keycloak crd.yaml. However these yaml files can be imported into Openshift 4 and Kubernetes 1.16 clusters. 

## Solution 

Openshift 3.11 does not support `type:object` which the latest operator-sdk generates.  This PR adds CRDs that are compatible with the Openshift 3.11 API and includes an updated README with install instructions. 

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>