### PR TITLE
Set PFE service in Gatekeeper

### DIFF
--- a/pkg/controller/codewind/builders.go
+++ b/pkg/controller/codewind/builders.go
@@ -13,6 +13,7 @@ package codewind
 
 import (
 	"strconv"
+	"strings"
 
 	codewindv1alpha1 "github.com/eclipse/codewind-operator/pkg/apis/codewind/v1alpha1"
 	defaults "github.com/eclipse/codewind-operator/pkg/controller/defaults"
@@ -408,7 +409,7 @@ func (r *ReconcileCodewind) deploymentForCodewindGatekeeper(codewind *codewindv1
 							},
 							{
 								Name:  "WORKSPACE_SERVICE",
-								Value: "CODEWIND_PFE_" + deploymentOptions.WorkspaceID,
+								Value: "CODEWIND_PFE_" + strings.ToUpper(deploymentOptions.WorkspaceID),
 							},
 							{
 								Name:  "WORKSPACE_ID",


### PR DESCRIPTION
## Problem

Fixes an error `ENOTFOUND`when accessing gatekeeper using a browser or IDE and when Deployment is on Cloud OCP4. This happens when Gatekeeper is unable to determine the service address for PFE.   As seen in Issue https://github.com/eclipse/codewind/issues/2596

## Solution

Gatekeeper was unable to find environment variable holding SERVICE_HOST and SERVICE_PORT of the PFE service. These environment variables are all uppercase when accessed from inside the pod.  This PR makes the variable names consistent.

Tested change in both OpenShift 4, OpenShift 3.11 and Kubernetes on IBM Cloud 

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>