### PR TITLE
Replace dash with underscore in var name

### DIFF
--- a/pkg/controller/codewind/builders.go
+++ b/pkg/controller/codewind/builders.go
@@ -362,10 +362,14 @@ func (r *ReconcileCodewind) serviceForCodewindGatekeeper(codewind *codewindv1alp
 	return service
 }
 
-// deploymentForCodewindGatekeeper returns a Codewind dployment object
+// deploymentForCodewindGatekeeper returns a Codewind deployment object
 func (r *ReconcileCodewind) deploymentForCodewindGatekeeper(codewind *codewindv1alpha1.Codewind, deploymentOptions DeploymentOptionsCodewind, isOnOpenshift bool, keycloakRealm string, keycloakClientID string, keycloakAuthURL string, ingressDomain string) *appsv1.Deployment {
 	ls := labelsForCodewindGatekeeper(deploymentOptions)
 	replicas := int32(1)
+
+	// Replace any dash characters in the WorkspaceID to understore characters to match variable formats created by Kubernetes
+	workspaceServiceSuffix := strings.ReplaceAll(strings.ToUpper(deploymentOptions.WorkspaceID), "-", "_")
+
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      defaults.PrefixCodewindGatekeeper + "-" + deploymentOptions.WorkspaceID,
@@ -409,7 +413,7 @@ func (r *ReconcileCodewind) deploymentForCodewindGatekeeper(codewind *codewindv1
 							},
 							{
 								Name:  "WORKSPACE_SERVICE",
-								Value: "CODEWIND_PFE_" + strings.ToUpper(deploymentOptions.WorkspaceID),
+								Value: "CODEWIND_PFE_" + workspaceServiceSuffix,
 							},
 							{
 								Name:  "WORKSPACE_ID",


### PR DESCRIPTION
## Problem

When deploying Codewind,  if the user had named their deployment with a string containing a dash char eg "mycodewind-1", the gatekeeper is currently unable to find the PFE service.

Kube creates the service port and name and stores them in environment variables within the Gatekeeper container however it auto replaces dashes with underscores. 

## Solution

When setting  env var WORKSPACE_SERVICE,  replace any dash chars with underscores to match the variable names set by Kubernetes.

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>