### PR TITLE
Fix for docker images being uploaded with tag of master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,7 +134,7 @@ spec:
                             # If CHANGE_TARGET is set then this is a PR so don't push to master.
                             if [ -z "$CHANGE_TARGET" ]; then
                                 export TAG=$GIT_BRANCH
-                                if [[ $GIT_BRANCH == "master" ]]; then
+                                if [ "$GIT_BRANCH" = "master" ]; then
                                     TAG="latest"
                                 fi
                                 docker tag eclipse/codewind-operator-amd64:latest eclipse/codewind-operator-amd64:$TAG


### PR DESCRIPTION
The wrong shell syntax is being used to check if we should tag a build as latest so the most recent master build of the operator was uploaded as `eclipse/codewind-operator-amd64:master` instead of `eclipse/codewind-operator-amd64:latest`.

See: https://hub.docker.com/r/eclipse/codewind-operator-amd64/tags