### PR TITLE
Update tags to 0.11.0

### DIFF
--- a/pkg/controller/defaults/defaults.go
+++ b/pkg/controller/defaults/defaults.go
@@ -27,31 +27,31 @@ const (
 
 const (
 	// VersionNum : Operator version number
-	VersionNum = "0.11.0"
+	VersionNum = "0.0.1"
 
 	// KeycloakImage is the docker image that will be used in the Codewind-Keycloak pod
 	KeycloakImage = "eclipse/codewind-keycloak-amd64"
 
 	// KeycloakImageTag is the Image tag used by Keycloak
-	KeycloakImageTag = "0.10.0"
+	KeycloakImageTag = "0.11.0"
 
 	// CodewindImage is the docker image that will be used in the Codewind-pfe pod
 	CodewindImage = "eclipse/codewind-pfe-amd64"
 
 	// CodewindImageTag is the Image tag used by Codewind
-	CodewindImageTag = "0.10.0"
+	CodewindImageTag = "0.11.0"
 
 	// CodewindPerformanceImage is the docker image that will be used in the Codewind-Performance pod
 	CodewindPerformanceImage = "eclipse/codewind-performance-amd64"
 
 	// CodewindPerformanceImageTag is the Image tag used by Codewind
-	CodewindPerformanceImageTag = "0.10.0"
+	CodewindPerformanceImageTag = "0.11.0"
 
 	// CodewindGatekeeperImage is the docker image that will be used in the Codewind-Gatekeeper pod
 	CodewindGatekeeperImage = "eclipse/codewind-gatekeeper-amd64"
 
 	// CodewindGatekeeperImageTag is the Image tag used by Codewind
-	CodewindGatekeeperImageTag = "0.10.0"
+	CodewindGatekeeperImageTag = "0.11.0"
 
 	// CodewindAuthRealm : Codewind security realm within Keycloak
 	CodewindAuthRealm = "codewind"

--- a/pkg/controller/defaults/defaults.go
+++ b/pkg/controller/defaults/defaults.go
@@ -27,7 +27,7 @@ const (
 
 const (
 	// VersionNum : Operator version number
-	VersionNum = "0.0.1"
+	VersionNum = "0.11.0"
 
 	// KeycloakImage is the docker image that will be used in the Codewind-Keycloak pod
 	KeycloakImage = "eclipse/codewind-keycloak-amd64"


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

## What type of PR is this ?

- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2693

## What does this PR do ?
Updates the image tags for the images that the 0.11.0 Codewind operator pulls to be 0.11.0.

## Does this PR require a documentation change ?
N/A

## Any special notes for your reviewer ?
N/A