### PR TITLE
[0.12.0] Grant anyuid policy to Codewind SA

### DIFF
--- a/pkg/controller/codewind/rbac.go
+++ b/pkg/controller/codewind/rbac.go
@@ -26,7 +26,7 @@ func (r *ReconcileCodewind) clusterRolesForCodewind(codewind *codewindv1alpha1.C
 			APIGroups:     []string{"security.openshift.io"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
-			ResourceNames: []string{"privileged"},
+			ResourceNames: []string{"privileged", "anyuid"},
 		},
 		rbacv1.PolicyRule{
 			APIGroups: []string{"extensions", ""},

--- a/pkg/controller/defaults/defaults.go
+++ b/pkg/controller/defaults/defaults.go
@@ -26,8 +26,8 @@ const (
 )
 
 const (
-	// VersionNum : Operator version number
-	VersionNum = "0.12.0"
+	// VersionNum : Operator Version number
+	VersionNum = "0.12.0" //
 
 	// KeycloakImage is the docker image that will be used in the Codewind-Keycloak pod
 	KeycloakImage = "eclipse/codewind-keycloak-amd64"

--- a/pkg/controller/defaults/defaults.go
+++ b/pkg/controller/defaults/defaults.go
@@ -26,8 +26,8 @@ const (
 )
 
 const (
-	// VersionNum : Operator Version number
-	VersionNum = "0.12.0" //
+	// VersionNum : Operator version number
+	VersionNum = "0.12.0"
 
 	// KeycloakImage is the docker image that will be used in the Codewind-Keycloak pod
 	KeycloakImage = "eclipse/codewind-keycloak-amd64"


### PR DESCRIPTION
Signed-off-by: Mark Cornaia <mark.cornaia@uk.ibm.com>

## What type of PR is this ?

- [x] Bug fix

## Which issue(s) does this PR fix ? https://github.com/eclipse/codewind/issues/2872

## What does this PR do ?

Grants the 'anyuid` policy to Codewind service account.

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
NO

## Any special notes for your reviewer ?

If you are trying this fix out, you will need to delete the existing clusterrole called "eclipse-codewind-0.12.0".  That cluster role would have originally been deployed alongside the operator and is not patched by this PR. This PR creates a new clusterrole (when one does not exist) and sets it with the extra permission.