### PR TITLE
Mount TLS certificate in Gatekeeper

### DIFF
--- a/pkg/controller/codewind/builders.go
+++ b/pkg/controller/codewind/builders.go
@@ -389,10 +389,23 @@ func (r *ReconcileCodewind) deploymentForCodewindGatekeeper(codewind *codewindv1
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: deploymentOptions.CodewindServiceAccountName,
+					Volumes: []corev1.Volume{{
+						Name: "tls-certs",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: deploymentOptions.CodewindGatekeeperSecretTLSName,
+							},
+						},
+					}},
 					Containers: []corev1.Container{{
 						Name:            defaults.PrefixCodewindGatekeeper,
 						Image:           defaults.CodewindGatekeeperImage + ":" + defaults.CodewindGatekeeperImageTag,
 						ImagePullPolicy: corev1.PullAlways,
+						VolumeMounts: []corev1.VolumeMount{{
+							MountPath: "/tlscerts",
+							Name:      "tls-certs",
+							ReadOnly:  true,
+						}},
 						Env: []corev1.EnvVar{
 							{
 								Name:  "AUTH_URL",

--- a/pkg/util/tlsutils.go
+++ b/pkg/util/tlsutils.go
@@ -30,12 +30,12 @@ func GenerateCertificate(dnsName string, certTitle string) (string, string, erro
 	var log = logf.Log.WithName("controller_codewind_tlsutils.go")
 
 	template := x509.Certificate{
-		SerialNumber: big.NewInt(1),
+		SerialNumber: big.NewInt(time.Now().UnixNano() / 1000000),
 		Subject: pkix.Name{
 			Organization: []string{certTitle},
 		},
 		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(time.Hour * 24 * 180),
+		NotAfter:              time.Now().Add(time.Hour * 24 * 730),
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,


### PR DESCRIPTION
## What type of PR is this ?

- [x] Enhancement

## Which issue(s) does this PR fix ? https://github.com/eclipse/codewind/issues/971

## What does this PR do ?

Mount the generated TLS certificate into the Codewind Gatekeeper pod. This makes it much easier for users to provide their own server certificate and keys.  It also avoids issues where Gatekeeper pod restarts will regenerate a new self-signed certificate each time which will fire the browser certificate has changed alerts. By using the same certificate each time the browser only needs to trust the self-signed certificate once. 

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?

## Any special notes for your reviewer ?

With this pr installed,  the operator will deploy the gatekeeper pod with certificates mounted into /tlscerts directory eg : 

```
drwxrwxrwt. 3 root root  120 May 12 22:28 .
drwxr-xr-x. 1 root root 4096 May 12 22:28 ..
drwxr-xr-x. 2 root root   80 May 12 22:28 ..2020_05_12_22_28_40.146678972
lrwxrwxrwx. 1 root root   31 May 12 22:28 ..data -> ..2020_05_12_22_28_40.146678972
lrwxrwxrwx. 1 root root   14 May 12 22:28 tls.crt -> ..data/tls.crt
lrwxrwxrwx. 1 root root   14 May 12 22:28 tls.key -> ..data/tls.key
bash-4.4$ 
```

Signed-off-by: Mark Cornaia <mark.cornaia@uk.ibm.com>