### PR TITLE
Remove duplicate echo

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -135,7 +135,6 @@ function installCodewind() {
     exit
     fi
 
-    echo "Creating Codewind deployment"
     cd crds
 #    cp codewind.eclipse.org_v1alpha1_codewind_cr.yaml custom-codewind.eclipse.org_v1alpha1_codewind_cr.yaml
 #   sed -i "" "s|name: jane1|name: $FLG_CW_NAME|g" custom-codewind.eclipse.org_v1alpha1_codewind_cr.yaml
@@ -153,14 +152,12 @@ function installCodewind() {
     kubectl create -f custom-codewind.eclipse.org_v1alpha1_codewind_cr.yaml
     rm -f custom-codewind.eclipse.org_v1alpha1_codewind_cr.yaml
     cd ..
-    echo "Check status using the command 'kubectl get codewinds'"
-    echo ""
     echo ""
  
     containerRunning=false
     lastContainerStatus="unknown"
     pfeName="codewind-pfe-"$FLG_CW_NAME
-    echo "Waiting for codewind (may take a few minutes Pending->ContainerCreating->Running)"
+    echo "Waiting for codewind (may take a few minutes, expected phases: Pending->ContainerCreating->Running)"
     while [ $containerRunning != true ]
     do
        containerStatus=$(kubectl get pods -n codewind | grep $pfeName | awk '{print $3}')


### PR DESCRIPTION
Signed-off-by: Mark Cornaia <mark.cornaia@uk.ibm.com>

## What type of PR is this ?

- [x] Bug fix

## What does this PR do ?

Cleans up the echo statements in the install.sh removing a duplicate message and one which invites the user to run a kubectl command to check status (which they no longer need to do since install.sh displays the deployment phase directly). 

## Does this PR require a documentation change ?
NO

## Any special notes for your reviewer ?

Example output with new change : 

```
$ ./install.sh codewind -n jane2 -u jane
###########################
Codewind Operator install.sh
############################
----------------------------------
Install a new Codewind deployment
----------------------------------
Have you remembered to set up 'jane' in the Keycloak directory (y/n)?y
Creating Codewind deployment
codewind.codewind.eclipse.org/jane2 created

Waiting for codewind (may take a few minutes, expected phases: Pending->ContainerCreating->Running)

codewind  Pending
codewind  ContainerCreating
codewind  Running

NAME    USERNAME   NAMESPACE   AGE     KEYCLOAK   REGISTRATION   ACCESSURL
jane1   jane       codewind    7m23s   devex001   Complete       https://codewind-gatekee...
jane2   jane       codewind    113s    devex001   Complete       https://codewind-gatekeep...
$
```