### PR TITLE
Set RBAC permissions for using the ODO extension with Codewind

### DIFF
--- a/deploy/cluster_roles.yaml
+++ b/deploy/cluster_roles.yaml
@@ -34,7 +34,7 @@ rules:
 
   - apiGroups: [""]
     resources: ["persistentvolumeclaims",persistentvolumeclaims/finalizers,"persistentvolumeclaims/status"]
-    verbs: ["*","get", "list", "watch", "update"]
+    verbs: ["*","create", "delete", "deletecollection", "get", "list", "patch", "watch", "update"]
 
   - apiGroups: [""]
     resources: ["pods"]
@@ -46,7 +46,7 @@ rules:
 
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "watch", "list", "create","patch","update", "delete"]
+    verbs: ["get", "watch", "list", "create", "patch","update", "delete", "deletecollection"]
 
   - apiGroups: [""]
     resources: ["serviceaccounts"]
@@ -76,6 +76,10 @@ rules:
     resources: ["replicasets/finalizers"]
     verbs: ["get","list","update","delete"]
 
+  - apiGroups: ["build.openshift.io"]
+    resources: ["buildconfigs"]
+    verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+
   - apiGroups: ["icp.ibm.com"]
     resources: ["images"]
     verbs: ["get","list","create","watch"]
@@ -96,6 +100,38 @@ rules:
     resources: ["replicasets","replicasets/finalizers"]
     verbs: ["get","list","update","delete"]
 
+  - apiGroups: ["image.openshift.io"]
+    resources: ["images", "imagestreams"]
+    verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+
+  - apiGroups: ["image.openshift.io"]
+    resources: ["imagesignatures"]
+    verbs: ["create", "delete"]
+
+  - apiGroups: ["image.openshift.io"]
+    resources: ["imagestreamimages"]
+    verbs: ["get"]
+
+  - apiGroups: ["image.openshift.io"]
+    resources: ["imagestreamimports", "imagestreammappings"]
+    verbs: ["create"]
+
+  - apiGroups: ["image.openshift.io"]
+    resources: ["imagestreamtags"]
+    verbs: ["create", "delete", "get", "list", "patch", "update"]
+
+  - apiGroups: ["apps.openshift.io"]
+    resources: ["deploymentconfigs"]
+    verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+
+  - apiGroups: ["project.openshift.io"]
+    resources: ["projectrequests"]
+    verbs: ["create", "list"]
+
+  - apiGroups: ["project.openshift.io"]
+    resources: ["projects"]
+    verbs: ["create", "delete", "get", "list", "watch", "patch", "update", "watch"]
+
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["clusterroles"]
     verbs: ["get","create","list","patch","watch","delete"]
@@ -114,7 +150,7 @@ rules:
 
   - apiGroups: ["route.openshift.io"]
     resources: ["routes","routes/custom-host"]
-    verbs: ["watch","get","list","create","update","delete","patch"]
+    verbs: ["watch","get","list","create","update","delete","deletecollection","patch"]
 
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -67,56 +67,51 @@ function installOperator() {
     kubectl create namespace codewind
 
     echo "Deploying Operator Service Account:"
-    kubectl create -f service_account.yaml
+    kubectl apply -f service_account.yaml
 
     echo "Deploying Operator RBAC Roles:"
-    kubectl create -f role.yaml
+    kubectl apply -f role.yaml
 
     echo "Deploying Operator RBAC Role Bindings:"
-    kubectl create -f role_binding.yaml
+    kubectl apply -f role_binding.yaml
 
     echo "Deploying Operator Cluster Roles:"
-    kubectl create -f cluster_roles.yaml
+    kubectl apply -f cluster_roles.yaml
 
     echo "Deploying Codewind Cluster Role Bindings:"
-    kubectl create -f cluster_role_binding.yaml
+    kubectl apply -f cluster_role_binding.yaml
     echo ""
 
     cd crds
     if [[ $FLG_OC311 == true ]]
     then
     echo "Installing Custom Resource Definitions (CRD) for Openshift 3.11:"
-    kubectl create -f codewind.eclipse.org_keycloaks_crd-oc311.yaml
-    kubectl create -f codewind.eclipse.org_codewinds_crd-oc311.yaml
+    kubectl apply -f codewind.eclipse.org_keycloaks_crd-oc311.yaml
+    kubectl apply -f codewind.eclipse.org_codewinds_crd-oc311.yaml
     else
     echo "Installing Custom Resource Definitions (CRD):"
-    kubectl create -f codewind.eclipse.org_keycloaks_crd.yaml
-    kubectl create -f codewind.eclipse.org_codewinds_crd.yaml
+    kubectl apply -f codewind.eclipse.org_keycloaks_crd.yaml
+    kubectl apply -f codewind.eclipse.org_codewinds_crd.yaml
     fi
 
     cd ..
 
     echo "Creating Codewind configmap:"
-    #cp codewind-configmap.yaml custom-codewind-configmap.yaml
-    #sed -i "" "s|codewind.apps-crc.testing|$FLG_INGRESS_DOMAIN|g" custom-codewind-configmap.yaml
-
-# updated as sed not available on Windows
-
 
     head -n17 codewind-configmap.yaml > custom-codewind-configmap.yaml
     echo "  ingressDomain: "$FLG_INGRESS_DOMAIN >> custom-codewind-configmap.yaml
     tail -n3 codewind-configmap.yaml >> custom-codewind-configmap.yaml
 
-    kubectl create -f custom-codewind-configmap.yaml
+    kubectl apply -f custom-codewind-configmap.yaml
     rm -f custom-codewind-configmap.yaml
 
     echo "Deploying Codewind operator:"
-    kubectl create -f operator.yaml
+    kubectl apply -f operator.yaml
 
     cd crds
 
     echo "Requesting a new Keycloak service"
-    kubectl create -f codewind.eclipse.org_v1alpha1_keycloak_cr.yaml
+    kubectl apply -f codewind.eclipse.org_v1alpha1_keycloak_cr.yaml
 
     cd ..
 
@@ -137,9 +132,9 @@ function installOperator() {
         lastContainerStatus=$containerStatus
       fi
 
-      if [[ $containerStatus == "Running" ]] 
+      if [[ $containerStatus == "Running" ]]
       then
-        containerRunning=true 
+        containerRunning=true
       else
         sleep 5
       fi
@@ -185,8 +180,6 @@ function installCodewind() {
 
     cd crds
 
-# updated as sed not available on Windows
-
     head -n15 codewind.eclipse.org_v1alpha1_codewind_cr.yaml > custom-codewind.eclipse.org_v1alpha1_codewind_cr.yaml
     echo "  name: "$FLG_CW_NAME >> custom-codewind.eclipse.org_v1alpha1_codewind_cr.yaml
     echo "  namespace: codewind" >> custom-codewind.eclipse.org_v1alpha1_codewind_cr.yaml
@@ -194,7 +187,7 @@ function installCodewind() {
     echo "  keycloakDeployment: devex001"  >> custom-codewind.eclipse.org_v1alpha1_codewind_cr.yaml
     echo "  username: "$FLG_CW_USERNAME >> custom-codewind.eclipse.org_v1alpha1_codewind_cr.yaml
     tail -n2 codewind.eclipse.org_v1alpha1_codewind_cr.yaml >> custom-codewind.eclipse.org_v1alpha1_codewind_cr.yaml 
-    kubectl create -f custom-codewind.eclipse.org_v1alpha1_codewind_cr.yaml
+    kubectl apply -f custom-codewind.eclipse.org_v1alpha1_codewind_cr.yaml
     rm -f custom-codewind.eclipse.org_v1alpha1_codewind_cr.yaml
     cd ..
     echo ""
@@ -219,7 +212,7 @@ function installCodewind() {
          sleep 5
        fi
     done
-    
+
     echo ""
     kubectl get codewinds $FLG_CW_NAME -n codewind
     exit

--- a/pkg/controller/codewind/codewind_controller.go
+++ b/pkg/controller/codewind/codewind_controller.go
@@ -49,7 +49,6 @@ var log = logf.Log.WithName("controller_codewind")
 // DeploymentOptionsCodewind : Configuration settings of a Codewind deployment
 type DeploymentOptionsCodewind struct {
 	TektonRoleBindingName               string
-	ODORoleBindingName                  string
 	WorkspaceID                         string
 	CodewindRolesName                   string
 	CodewindRoleBindingName             string
@@ -199,7 +198,6 @@ func (r *ReconcileCodewind) Reconcile(request reconcile.Request) (reconcile.Resu
 		CodewindRolesName:                   defaults.CodewindRolesName,
 		CodewindServiceAccountName:          "codewind-" + workspaceID,
 		TektonRoleBindingName:               defaults.CodewindTektonClusterRoleBindingName + "-" + workspaceID,
-		ODORoleBindingName:                  defaults.CodewindODOClusterRoleBindingName + "-" + workspaceID,
 		CodewindRoleBindingName:             defaults.CodewindRoleBindingNamePrefix + "-" + workspaceID,
 		CodewindTektonClusterRolesName:      defaults.CodewindTektonClusterRolesName,
 		CodewindTektonRoleBindingName:       defaults.CodewindTektonClusterRoleBindingName + "-" + workspaceID,

--- a/pkg/controller/codewind/finalizer.go
+++ b/pkg/controller/codewind/finalizer.go
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package codewind
+
+import (
+	"context"
+
+	codewindv1alpha1 "github.com/eclipse/codewind-operator/pkg/apis/codewind/v1alpha1"
+	defaults "github.com/eclipse/codewind-operator/pkg/controller/defaults"
+
+	"github.com/go-logr/logr"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// addCodewindFinalizer : Adds the finalizer to the metadata of the Codewind CR
+func (r *ReconcileCodewind) addCodewindFinalizer(reqLogger logr.Logger, codewind *codewindv1alpha1.Codewind, request reconcile.Request) error {
+	if len(codewind.GetFinalizers()) < 1 && codewind.GetDeletionTimestamp() == nil {
+		reqLogger.Info("Adding Finalizer to Codewind", "namespace", codewind.Namespace, "name", codewind.Name, "finalizer", defaults.CodewindFinalizerName)
+		codewind.SetFinalizers([]string{defaults.CodewindFinalizerName})
+		err := r.client.Update(context.TODO(), codewind)
+		if err != nil {
+			reqLogger.Error(err, "Failed to update Codewind with the CRB finalizer", "namespace", codewind.Namespace, "name", codewind.Name, "finalizer", defaults.CodewindFinalizerName)
+			return err
+		}
+	}
+	return nil
+}
+
+// removeFinalizers  : Removes all the finalizers from the Codewind CR
+func (r *ReconcileCodewind) removeFinalizers(codewind *codewindv1alpha1.Codewind) error {
+	codewind.SetFinalizers(nil)
+	err := r.client.Update(context.TODO(), codewind)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// handleCodewindCRBFinalizer : Perform cleanup of cluster role bindings
+func (r *ReconcileCodewind) handleCodewindCRBFinalizer(codewind *codewindv1alpha1.Codewind, deploymentOptions DeploymentOptionsCodewind, reqLogger logr.Logger, request reconcile.Request) error {
+	if len(codewind.GetFinalizers()) == 0 && codewind.GetDeletionTimestamp() == nil {
+		return nil
+	}
+
+	// Delete the ODO CRB
+	crbODO := &rbacv1.ClusterRoleBinding{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: deploymentOptions.CodewindODORoleBindingName, Namespace: ""}, crbODO)
+	if err == nil {
+		deleteErr := r.client.Delete(context.TODO(), crbODO)
+		if deleteErr != nil {
+			reqLogger.Error(err, "Unable to remove the cluster role binding", "namespace", codewind.Namespace, "name", codewind.Name, "crb", deploymentOptions.CodewindODORoleBindingName)
+			return err
+		}
+	}
+
+	// Delete the Tekton CRB
+	crbTekton := &rbacv1.ClusterRoleBinding{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: deploymentOptions.CodewindTektonRoleBindingName, Namespace: ""}, crbTekton)
+	if err == nil {
+		deleteErr := r.client.Delete(context.TODO(), crbTekton)
+		if deleteErr != nil {
+			reqLogger.Error(err, "Unable to remove the cluster role binding", "namespace", codewind.Namespace, "name", codewind.Name, "crb", deploymentOptions.CodewindTektonRoleBindingName)
+			return err
+		}
+	}
+
+	err = r.removeFinalizers(codewind)
+	if err != nil {
+		reqLogger.Error(err, "Failed to remove the Codewind finalizer", "namespace", codewind.Namespace, "name", codewind.Name)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controller/codewind/rbac.go
+++ b/pkg/controller/codewind/rbac.go
@@ -301,5 +301,6 @@ func (r *ReconcileCodewind) roleBindingForCodewindODO(codewind *codewindv1alpha1
 			APIGroup: "rbac.authorization.k8s.io",
 		},
 	}
+
 	return rolebinding
 }

--- a/pkg/controller/codewind/rbac.go
+++ b/pkg/controller/codewind/rbac.go
@@ -133,6 +133,87 @@ func (r *ReconcileCodewind) clusterRolesForCodewindTekton(codewind *codewindv1al
 	}
 }
 
+// clusterRolesForCodewindODO : create Codewind ODO cluster roles
+func (r *ReconcileCodewind) clusterRolesForCodewindODO(codewind *codewindv1alpha1.Codewind, deploymentOptions DeploymentOptionsCodewind) *rbacv1.ClusterRole {
+	ourRoles := []rbacv1.PolicyRule{
+		rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"services"},
+			Verbs:     []string{"get", "list"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"route.openshift.io"},
+			Resources: []string{"routes"},
+			Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"build.openshift.io"},
+			Resources: []string{"buildconfigs"},
+			Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"persistentvolumeclaims"},
+			Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"project.openshift.io"},
+			Resources: []string{"projectrequests"},
+			Verbs:     []string{"create", "list"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"project.openshift.io"},
+			Resources: []string{"projects"},
+			Verbs:     []string{"create", "delete", "get", "list", "watch", "patch", "update", "watch"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"image.openshift.io"},
+			Resources: []string{"images", "imagestreams"},
+			Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"image.openshift.io"},
+			Resources: []string{"imagesignatures"},
+			Verbs:     []string{"create", "delete"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"image.openshift.io"},
+			Resources: []string{"imagestreamimages"},
+			Verbs:     []string{"get"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"image.openshift.io"},
+			Resources: []string{"imagestreamimports", "imagestreammappings"},
+			Verbs:     []string{"create"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"image.openshift.io"},
+			Resources: []string{"imagestreamtags"},
+			Verbs:     []string{"create", "delete", "get", "list", "patch", "update"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"apps.openshift.io"},
+			Resources: []string{"deploymentconfigs"},
+			Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+		},
+	}
+	return &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1beta1",
+			Kind:       "ClusterRole",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: deploymentOptions.CodewindODOClusterRolesName,
+		},
+		Rules: ourRoles,
+	}
+}
+
 //roleBindingForCodewind : create Codewind role bindings in the deployment namespace
 func (r *ReconcileCodewind) roleBindingForCodewind(codewind *codewindv1alpha1.Codewind, deploymentOptions DeploymentOptionsCodewind) *rbacv1.RoleBinding {
 	labels := labelsForCodewindPFE(deploymentOptions)
@@ -191,5 +272,34 @@ func (r *ReconcileCodewind) roleBindingForCodewindTekton(codewind *codewindv1alp
 		},
 	}
 
+	return rolebinding
+}
+
+//roleBindingForCodewindODO : create Codewind ODO cluster role bindings
+func (r *ReconcileCodewind) roleBindingForCodewindODO(codewind *codewindv1alpha1.Codewind, deploymentOptions DeploymentOptionsCodewind) *rbacv1.ClusterRoleBinding {
+	labels := labelsForCodewindPFE(deploymentOptions)
+	rolebinding := &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1beta1",
+			Kind:       "ClusterRoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentOptions.CodewindODORoleBindingName,
+			Labels:    labels,
+			Namespace: codewind.Namespace,
+		},
+		Subjects: []rbacv1.Subject{
+			rbacv1.Subject{
+				Kind:      "ServiceAccount",
+				Name:      deploymentOptions.CodewindServiceAccountName,
+				Namespace: codewind.Namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     deploymentOptions.CodewindODOClusterRolesName,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
 	return rolebinding
 }

--- a/pkg/controller/defaults/defaults.go
+++ b/pkg/controller/defaults/defaults.go
@@ -27,7 +27,7 @@ const (
 
 const (
 	// VersionNum : Operator version number
-	VersionNum = "0.0.1"
+	VersionNum = "latest"
 
 	// KeycloakImage is the docker image that will be used in the Codewind-Keycloak pod
 	KeycloakImage = "eclipse/codewind-keycloak-amd64"
@@ -105,4 +105,7 @@ const (
 
 	// OperatorConfigMapName : Codewind operator config map name
 	OperatorConfigMapName = "codewind-operator"
+
+	// CodewindFinalizerName : Codewind Cluster role binding finalizer
+	CodewindFinalizerName = "crb.finalizer.codewind.eclipse"
 )

--- a/pkg/controller/defaults/defaults.go
+++ b/pkg/controller/defaults/defaults.go
@@ -77,6 +77,12 @@ const (
 	// CodewindTektonClusterRolesName : Tekton, cluster role
 	CodewindTektonClusterRolesName = "codewind-tekton"
 
+	// CodewindODOClusterRoleBindingName : ODO, cluster role binding
+	CodewindODOClusterRoleBindingName = "codewind-odo-rolebinding"
+
+	// CodewindODOClusterRolesName : ODO, cluster role
+	CodewindODOClusterRolesName = "codewind-odoclusterrole"
+
 	// CodewindRolesName will include the workspaceID when deployed
 	CodewindRolesName = "eclipse-codewind-" + VersionNum
 )

--- a/pkg/util/kubeutils.go
+++ b/pkg/util/kubeutils.go
@@ -69,6 +69,3 @@ func GetOperatorNamespace() string {
 	}
 	return operatorNamespace
 }
-
-
-


### PR DESCRIPTION
## What type of PR is this ?

- [x] Enhancement

## Which issue(s) does this PR fix ? 3002

## What does this PR do ?

1. Installs the new ODO extension cluster roles for Codewind to build and run projects via the ODO extension 
2. Installs a new binding to the Codewind service account
3. Adds finalisers to the Codewind CR so that it can remove the cluster role bindings when deleting the deployment. 
4. Changes the version number of the bindings to "latest" in master rather than 0.0.1 

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

https://github.com/eclipse/codewind/issues/3002

## Does this PR require a documentation change ?

When upgrading to the new operator version you should update the cluster roles for the operator eg : `kubectl apply -f ./deploy/cluster_roles.yaml` 

## Any special notes for your reviewer ?
  
If you are testing using an existing cluster with an existing operator and just want to use the new operator image, you will still need to grant the operator the extra RBAC roles required to allow it to assign ODO permissions to Codewinds. (see docs note above)

Key things to test once the new operator starts up:

1.  Check the cluster role eclipse-codewind-latest has been created
2. Check that the crb finaliser has been added to any existing instances of Codewind (kubectl get codewind {codewindDeploymentName} -o jsonpath="{.metadata.finalizers}"
3.  Create a new Codewind deployment and validate that the ODO cluster role has been created: 
`kubectl get clusterrole codewind-odoclusterrole`
4. Check that the ODO cluster role binding has been added for your new codewind instance: 
`kubectl get codewind-odo-rolebinding-{codewindDeploymentName}`
5. Create a new project in codewind, bind it to codewind,  then run the ODO commands to build and run it (ensure there are no permission errors) 
6. Delete your codewind deployment `kubectl delete codewind {codewindDeploymentName}`
7.  Check that the deployment is delete
8. Check that the cluster role bindings for ODO and TEKTON have both been removed, note that we do not remove the cluster role (only the bindings are removed) the cluster roles should be removed manually when removing the operator. 
