### PR TITLE
Use unique ID to name Kube resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,8 @@ $ kubectl apply -f ./deploy/crds/codewind.eclipse.org_v1alpha1_keycloak_cr.yaml
 keycloak.codewind.eclipse.org/devex001 created
 
 $ kubectl get keycloaks -n codewind
-NAME       NAMESPACE   AGE   ACCESS
-devex001   codewind    4s    https://codewind-keycloak-devex001.10.98.117.7.nip.io
+NAME       NAMESPACE   AUTHID         AGE   ACCESS
+devex001   codewind    kbc36enhx0cb   6s    https://codewind-keycloak-kbc36enhx0cb.codewind.apps.....195.90.nip.io
 ```
 
 During deployment, the operator creates the following items:
@@ -318,8 +318,8 @@ To see the Keycloak deployment running in the `codewind` namespace and capture i
 
 ```bash
 $ kubectl get keycloaks -n codewind
-NAME       NAMESPACE   AGE     ACCESS
-devex001   codewind    5m22s   https://codewind-keycloak-devex001.10.98.117.7.nip.io
+NAME       NAMESPACE   AUTHID         AGE    ACCESS
+devex001   codewind    kbc36enhx0cb   5m22s  https://codewind-keycloak-kbc36enhx0cb.codewind.apps.....195.90.nip.io
 ```
 
 By default, Keycloak is installed with an admin account where:
@@ -433,8 +433,8 @@ For example:
 
 ```bash
 $ kubectl get codewinds -n codewind jane1
-NAME      USERNAME   NAMESPACE   AGE     KEYCLOAK   REGISTRATION   ACCESSURL
-jane1   jane       codewind    2m23s   devex001   Complete       https://codewind-gatekeeper-cwjane1.10.98.117.7.nip.io
+NAME     USERNAME   NAMESPACE   WORKSPACE      AGE   KEYCLOAK   REGISTRATION   ACCESSURL
+jane1    jane       codewind    kbc3b0x2qins   2d    devex001   Complete       https://codewind-gatekeeper-kbc3b0x2qins.codewind.......90.nip.io
 ```
 
 You can check the status of the Codewind pods with `kubectl get pods -n codewind` to confirm they are in the `Ready` and `Running` phase
@@ -485,8 +485,8 @@ To view all the Codewind deployments in the `codewind` namespace:
 
 ```bash
 $ kubectl get codewinds -n codewind
-NAME                USERNAME   NAMESPACE   AGE   KEYCLOAK   AUTHSTATUS   ACCESSURL
-jane1               jane       codewind    23m   devex001   Completed    https://codewind-gatekeeper-jane1.10.98.117.7.nip.io
+NAME     USERNAME   NAMESPACE   WORKSPACE      AGE   KEYCLOAK   REGISTRATION   ACCESSURL
+jane1    jane       codewind    kbc3b0x2qins   2d    devex001   Complete       https://codewind-gatekeeper-kbc3b0x2qins.codewind.......90.nip.io
 ```
 
 The `kubectl get codewinds` command lists all the running Codewind deployments in the specified namespace. Each line represents a deployment and includes the user name of the developer it is assigned to, the Keycloak service name, and the auth config status. Most importantly, users need their Access URL, which they add to the IDE when creating a connection. Use the `-n` flag to target a specific namespace, for example, `-n codewind`.

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -1,12 +1,12 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: codewind-operator-clb
+  name: codewind-operator
 subjects:
   - kind: ServiceAccount
     name: codewind-operator
     namespace: codewind
 roleRef:
   kind: ClusterRole
-  name: codewind-operator-cluster
+  name: codewind-operator
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/cluster_roles.yaml
+++ b/deploy/cluster_roles.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: codewind-operator-cluster
+  name: codewind-operator
 rules:
 
   - apiGroups: [""]

--- a/deploy/crds/codewind.eclipse.org_codewinds_crd-oc311.yaml
+++ b/deploy/crds/codewind.eclipse.org_codewinds_crd-oc311.yaml
@@ -12,6 +12,10 @@ spec:
     description: Deployment namespace
     name: Namespace
     type: string
+  - JSONPath: .metadata.annotations.codewindWorkspace
+    description: WorkspaceID
+    name: Workspace
+    type: string
   - JSONPath: .metadata.creationTimestamp
     description: Age of the resource
     name: Age

--- a/deploy/crds/codewind.eclipse.org_codewinds_crd.yaml
+++ b/deploy/crds/codewind.eclipse.org_codewinds_crd.yaml
@@ -12,6 +12,10 @@ spec:
     description: Deployment namespace
     name: Namespace
     type: string
+  - JSONPath: .metadata.annotations.codewindWorkspace
+    description: WorkspaceID
+    name: Workspace
+    type: string
   - JSONPath: .metadata.creationTimestamp
     description: Age of the resource
     name: Age

--- a/deploy/crds/codewind.eclipse.org_keycloaks_crd-oc311.yaml
+++ b/deploy/crds/codewind.eclipse.org_keycloaks_crd-oc311.yaml
@@ -8,6 +8,10 @@ spec:
     description: Deployment namespace
     name: Namespace
     type: string
+  - JSONPath: .metadata.annotations.authID
+    description: Deployment AuthID
+    name: AuthID
+    type: string
   - JSONPath: .metadata.creationTimestamp
     description: Age of the resource
     name: Age

--- a/deploy/crds/codewind.eclipse.org_keycloaks_crd.yaml
+++ b/deploy/crds/codewind.eclipse.org_keycloaks_crd.yaml
@@ -8,6 +8,10 @@ spec:
     description: Deployment namespace
     name: Namespace
     type: string
+  - JSONPath: .metadata.annotations.authID
+    description: Deployment AuthID
+    name: AuthID
+    type: string
   - JSONPath: .metadata.creationTimestamp
     description: Age of the resource
     name: Age

--- a/pkg/apis/codewind/v1alpha1/codewind_types.go
+++ b/pkg/apis/codewind/v1alpha1/codewind_types.go
@@ -55,6 +55,7 @@ type CodewindStatus struct {
 // +kubebuilder:resource:path=codewinds,scope=Namespaced
 // +kubebuilder:printcolumn:name="Username",type="string",JSONPath=".spec.username",priority=0,description="Deployment reference name"
 // +kubebuilder:printcolumn:name="Namespace",type="string",JSONPath=".metadata.namespace",priority=0,description="Deployment namespace"
+// +kubebuilder:printcolumn:name="Workspace",type="string",JSONPath=".metadata.annotations.codewindWorkspace",priority=0,description="WorkspaceID"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",priority=0,description="Age of the resource"
 // +kubebuilder:printcolumn:name="Keycloak",type="string",JSONPath=".spec.keycloakDeployment",priority=0,description="Deployment reference name"
 // +kubebuilder:printcolumn:name="Registration",type="string",JSONPath=".status.keycloakStatus",priority=0,description="Keycloak configuration status"

--- a/pkg/apis/codewind/v1alpha1/keycloak_types.go
+++ b/pkg/apis/codewind/v1alpha1/keycloak_types.go
@@ -37,6 +37,7 @@ type KeycloakStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=keycloaks,scope=Namespaced
 // +kubebuilder:printcolumn:name="Namespace",type="string",JSONPath=".metadata.namespace",priority=0,description="Deployment namespace"
+// +kubebuilder:printcolumn:name="AuthID",type="string",JSONPath=".metadata.annotations.authID",priority=0,description="Deployment AuthID"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",priority=0,description="Age of the resource"
 // +kubebuilder:printcolumn:name="Access",type="string",JSONPath=".status.url",priority=0,description="Exposed route"
 type Keycloak struct {

--- a/pkg/controller/codewind/builders.go
+++ b/pkg/controller/codewind/builders.go
@@ -630,13 +630,13 @@ func (r *ReconcileCodewind) buildGatekeeperSecretAuth(codewind *codewindv1alpha1
 // labelsForCodewindPFE returns the labels for selecting the resources
 // belonging to the given codewind CR name.
 func labelsForCodewindPFE(deploymentOptions DeploymentOptionsCodewind) map[string]string {
-	return map[string]string{"app": defaults.PrefixCodewindPFE, "codewindWorkspace": deploymentOptions.WorkspaceID}
+	return map[string]string{"app": defaults.PrefixCodewindPFE, "codewindWorkspace": deploymentOptions.WorkspaceID, "codewindName": deploymentOptions.Name}
 }
 
 func labelsForCodewindPerformance(deploymentOptions DeploymentOptionsCodewind) map[string]string {
-	return map[string]string{"app": defaults.PrefixCodewindPerformance, "codewindWorkspace": deploymentOptions.WorkspaceID}
+	return map[string]string{"app": defaults.PrefixCodewindPerformance, "codewindWorkspace": deploymentOptions.WorkspaceID, "codewindName": deploymentOptions.Name}
 }
 
 func labelsForCodewindGatekeeper(deploymentOptions DeploymentOptionsCodewind) map[string]string {
-	return map[string]string{"app": defaults.PrefixCodewindGatekeeper, "codewindWorkspace": deploymentOptions.WorkspaceID}
+	return map[string]string{"app": defaults.PrefixCodewindGatekeeper, "codewindWorkspace": deploymentOptions.WorkspaceID, "codewindName": deploymentOptions.Name}
 }

--- a/pkg/controller/codewind/finalizer.go
+++ b/pkg/controller/codewind/finalizer.go
@@ -49,11 +49,13 @@ func (r *ReconcileCodewind) removeFinalizers(codewind *codewindv1alpha1.Codewind
 
 // handleCodewindCRBFinalizer : Perform cleanup of cluster role bindings
 func (r *ReconcileCodewind) handleCodewindCRBFinalizer(codewind *codewindv1alpha1.Codewind, deploymentOptions DeploymentOptionsCodewind, reqLogger logr.Logger, request reconcile.Request) error {
+	reqLogger.Info("Processing Finalizer", "namespace", codewind.Namespace, "name", codewind.Name, "finalizer", defaults.CodewindFinalizerName)
 	if len(codewind.GetFinalizers()) == 0 && codewind.GetDeletionTimestamp() == nil {
 		return nil
 	}
 
 	// Delete the ODO CRB
+	reqLogger.Info("Removing ODO CRB", "namespace", codewind.Namespace, "name", deploymentOptions.CodewindODORoleBindingName, "finalizer", defaults.CodewindFinalizerName)
 	crbODO := &rbacv1.ClusterRoleBinding{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: deploymentOptions.CodewindODORoleBindingName, Namespace: ""}, crbODO)
 	if err == nil {
@@ -62,9 +64,11 @@ func (r *ReconcileCodewind) handleCodewindCRBFinalizer(codewind *codewindv1alpha
 			reqLogger.Error(err, "Unable to remove the cluster role binding", "namespace", codewind.Namespace, "name", codewind.Name, "crb", deploymentOptions.CodewindODORoleBindingName)
 			return err
 		}
+		reqLogger.Info("Successfully removed ODO CRB", "namespace", codewind.Namespace, "name", deploymentOptions.CodewindODORoleBindingName, "finalizer", defaults.CodewindFinalizerName)
 	}
 
 	// Delete the Tekton CRB
+	reqLogger.Info("Removing TEKTON CRB", "namespace", codewind.Namespace, "name", deploymentOptions.CodewindTektonRoleBindingName, "finalizer", defaults.CodewindFinalizerName)
 	crbTekton := &rbacv1.ClusterRoleBinding{}
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: deploymentOptions.CodewindTektonRoleBindingName, Namespace: ""}, crbTekton)
 	if err == nil {
@@ -73,6 +77,7 @@ func (r *ReconcileCodewind) handleCodewindCRBFinalizer(codewind *codewindv1alpha
 			reqLogger.Error(err, "Unable to remove the cluster role binding", "namespace", codewind.Namespace, "name", codewind.Name, "crb", deploymentOptions.CodewindTektonRoleBindingName)
 			return err
 		}
+		reqLogger.Info("Successfully removed TEKTON CRB", "namespace", codewind.Namespace, "name", deploymentOptions.CodewindTektonRoleBindingName, "finalizer", defaults.CodewindFinalizerName)
 	}
 
 	err = r.removeFinalizers(codewind)
@@ -80,6 +85,7 @@ func (r *ReconcileCodewind) handleCodewindCRBFinalizer(codewind *codewindv1alpha
 		reqLogger.Error(err, "Failed to remove the Codewind finalizer", "namespace", codewind.Namespace, "name", codewind.Name)
 		return err
 	}
+	reqLogger.Info("Finalizer cleared", "namespace", codewind.Namespace, "name", codewind.Name, "finalizer", defaults.CodewindFinalizerName)
 
 	return nil
 }

--- a/pkg/util/kubeutils.go
+++ b/pkg/util/kubeutils.go
@@ -12,6 +12,7 @@
 package util
 
 import (
+	"math/rand"
 	"time"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -62,10 +63,22 @@ func CreateTimestamp() int64 {
 	return time.Now().UnixNano() / int64(time.Millisecond)
 }
 
+// GetOperatorNamespace : Operator namespace
 func GetOperatorNamespace() string {
 	operatorNamespace, _ := k8sutil.GetOperatorNamespace()
 	if operatorNamespace == "" {
 		operatorNamespace = "codewind"
 	}
 	return operatorNamespace
+}
+
+// GenerateRandomString : Generates random characters
+func GenerateRandomString(length int) string {
+	var options = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+	bytes := make([]rune, length)
+	rand.Seed(time.Now().UTC().UnixNano())
+	for i := range bytes {
+		bytes[i] = options[rand.Intn(len(options))]
+	}
+	return string(bytes)
 }


### PR DESCRIPTION
Signed-off-by: Mark Cornaia <mark.cornaia@uk.ibm.com>

## What type of PR is this ?

- [x] Bug fix
- [ ] Documentation

## Which issue(s) does this PR fix ?

In clusters with external dynamic storage (eg public cloud), using a unique name for the PVC ensures reuse of an old PV (previously bound with the same PVC name) can not be reused. 

## What does this PR do ?

Renames Kubernetes resources created by the Codewind Operator to avoid conflicts.
Renames Codewind role and cluster roles
Adds an additional column to the Codewind and Keycloak Custom resource definitions


Rather than using the name of the Codewind deployment as the part of a deployment, pod, secret, route, ingress, roles, cluster roles,  role binding or cluster role binding,  this PR switches over to using a unique string value instead. 

This also extends to the URL of both the Codewind Gatekeeper and the Keycloak deployments which will make it easier to move to supporting any-namespace installations (although that work will be completed in a different PR)

Since things like POD names have now changed using kubectl to list a set of pods can be tricky to filter those that make up a single Codewind deployment.  To assist with that, the CRDs for both Keycloak and Codewind have an additional column to display the uniqueID.  This value can be used to xvisually identify which kube resources are part of a Codewind deployment. 

Note below that the pods no longer contain the short name eg: 'jane1' of the Codewind  deployment and instead show random string after the application type: 

```
$ kubectl get pods
NAME                                                              READY   STATUS    RESTARTS   AGE
codewind-gatekeeper-kbc38mj7yw9n-6df4cb6699-2sr4x                 1/1     Running   0          2d
codewind-gatekeeper-kbc3b0x2qins-6545cdfc96-6vbjs                 1/1     Running   0          2d
codewind-keycloak-kbc36enhx0cb-57d4574584-mxt2w                   1/1     Running   0          2d
codewind-operator-5fc9c4469d-gzrbs                                1/1     Running   0          2d
codewind-performance-kbc38mj7yw9n-654bd84f8-dgj2q                 1/1     Running   0          2d
codewind-performance-kbc3b0x2qins-78d7775445-zclbs                1/1     Running   0          2d
codewind-pfe-kbc38mj7yw9n-6d65975db5-tjrcx                        1/1     Running   0          2d
codewind-pfe-kbc3b0x2qins-7c464446f6-9t57k                        1/1     Running   0          2d
cw-nodejsdoesingresschange-5448aa40-ac9e-11ea-8e3c-566dfc4npwvz   1/1     Running   0          2d
cw-openshift-nodejs-noclusterroles-app-1-j2vtn                    1/1     Running   0          2d
```

Note below that the PVC no longer contain the short name eg: 'jane1' of the Codewind deployment and instead show random string after the application type: 

```
$ kubectl get pvc
NAME                                             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
codewind-keycloak-pvc-kbc36enhx0cb               Bound    pvc-0ad1abf8-ac9a-11ea-aead-00000a3301df   1Gi        RWO            glusterfs-storage   2d
codewind-pfe-pvc-kbc38mj7yw9n                    Bound    pvc-4888bf78-ac9a-11ea-aead-00000a3301df   10Gi       RWX            glusterfs-storage   2d
codewind-pfe-pvc-kbc3b0x2qins                    Bound    pvc-8b04f52c-ac9a-11ea-aead-00000a3301df   10Gi       RWX            glusterfs-storage   2d
cw-openshift-nodejs-noclusterroles-app-s2idata   Bound    pvc-2862788c-ac9e-11ea-aead-00000a3301df   1Gi        RWO            glusterfs-storage   2d
```

Note below that the the list of Codewind deployments now have the new column (WORKSPACE) with a unique value for each deployment: 

```
$ kubectl get codewinds
NAME     USERNAME   NAMESPACE   WORKSPACE      AGE   KEYCLOAK   REGISTRATION   ACCESSURL
mark1    mark       codewind    kbc3b0x2qins   2d    devex001   Complete       https://codewind-gatekeeper-kbc3b0x2qins.codewind.......90.nip.io
jane1    jane       codewind    kbc38mj7yw9n   2d    devex001   Complete       https://codewind-gatekeeper-kbc38mj7yw9n.codewind.......90.nip.io
```

Note that the workspace value of  'kbc38mj7yw9n' is now used in the URL of the gatekeeper route and the names of pods and pvc and other resources.

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

https://github.com/eclipse/codewind/issues/2938

## Does this PR require a documentation change ?

## Any special notes for your reviewer ?

This PR changes the name scheme of kube resources. To deploy this fix you must first remove your existing codewind namespace but ensure you remove each codewind and keycloak deployment first eg : 

$ **kubectl delete codewind {codewindName}**      _<- REPEAT for each deployment you have_
$ **kubectl delete keycloak {keycloakName}**          _<- REPEAT for each deployment you have_
$ **kubectl delete namespace codewind**

Then deploy the operator, then deploy new codewinds, then reconnect your IDEs to your new instances. 